### PR TITLE
✨ Feature: #17 혼잡도 그래프 섹션 스와이프 기능

### DIFF
--- a/SubwayCongestion/SubwayCongestion/Assets.xcassets/Color/gray3.colorset/Contents.json
+++ b/SubwayCongestion/SubwayCongestion/Assets.xcassets/Color/gray3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.260",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x14"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
@@ -199,7 +199,7 @@ extension CongestionGraph {
     private func adjustedForRuleMark(_ date: Date) -> Date {
         let hour = calendar.component(.hour, from: date)
         
-        guard hour < 5, hour != 0 else { return date }
+        guard hour < 5 else { return date }
         
         return createDate(hour: 5, minute: 0, for: date)
     }

--- a/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
@@ -39,7 +39,7 @@ struct CongestionGraph: View {
                 if currentDate == roundedToHour(Date()) {
                     RectangleMark(
                         xStart: .value("시작", startTimeAt4AM),
-                        xEnd: .value("선택된 시각", adjustedForRuleMark(roundedToHour(currentDate)))
+                        xEnd: .value("선택된 시각", roundedToHour(currentDate))
                     )
                     .foregroundStyle(.gray3)
                     .accessibilityHidden(true)
@@ -199,7 +199,7 @@ extension CongestionGraph {
     private func adjustedForRuleMark(_ date: Date) -> Date {
         let hour = calendar.component(.hour, from: date)
         
-        guard hour < 5 else { return date }
+        guard hour < 5, hour != 0 else { return date }
         
         return createDate(hour: 5, minute: 0, for: date)
     }

--- a/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
@@ -29,16 +29,17 @@ struct CongestionGraph: View {
     var body: some View {
         VStack(alignment: .leading) {
             Chart {
-                chartMarks()
                 
                 RuleMark(x: .value("현재 위치", adjustedForRuleMark(roundedToHour(selectedDate))))
                     .lineStyle(StrokeStyle(lineWidth: 2))
                     .foregroundStyle(.black)
+                
+                chartMarks()
 
                 if currentDate == roundedToHour(Date()) {
                     RectangleMark(
                         xStart: .value("시작", startTimeAt4AM),
-                        xEnd: .value("선택된 시각", roundedToHour(currentDate))
+                        xEnd: .value("선택된 시각", adjustedForRuleMark(roundedToHour(currentDate)))
                     )
                     .foregroundStyle(.gray3)
                     .accessibilityHidden(true)
@@ -198,7 +199,7 @@ extension CongestionGraph {
     private func adjustedForRuleMark(_ date: Date) -> Date {
         let hour = calendar.component(.hour, from: date)
         
-        guard hour < 5 && hour != 0 else { return date }
+        guard hour < 5 else { return date }
         
         return createDate(hour: 5, minute: 0, for: date)
     }

--- a/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
@@ -142,7 +142,7 @@ extension CongestionGraph {
                 .contentShape(Rectangle())
                 .gesture(
                     LongPressGesture(minimumDuration: 0.2)
-                        .onEnded { _ in
+                        .onEnded { _ in // 0.2초 누른 경우 그래프 드래그 활성화
                             isDraggingEnabled = true
                         }
                 )
@@ -153,7 +153,7 @@ extension CongestionGraph {
                                 handleDrag(value: value, proxy: proxy, geo: geo)
                             }
                         }
-                        .onEnded { value in
+                        .onEnded { value in // 드래그 끝나면 그래프 드래그 비활성화
                             if isDraggingEnabled {
                                 handleDrag(value: value, proxy: proxy, geo: geo)
                             }

--- a/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/CongestionGraph.swift
@@ -31,7 +31,7 @@ struct CongestionGraph: View {
             Chart {
                 chartMarks()
                 
-                RuleMark(x: .value("현재 위치", adjustedForRuleMark(selectedDate)))
+                RuleMark(x: .value("현재 위치", adjustedForRuleMark(roundedToHour(selectedDate))))
                     .lineStyle(StrokeStyle(lineWidth: 2))
                     .foregroundStyle(.black)
 
@@ -40,7 +40,7 @@ struct CongestionGraph: View {
                         xStart: .value("시작", startTimeAt4AM),
                         xEnd: .value("선택된 시각", roundedToHour(currentDate))
                     )
-                    .foregroundStyle(.gray.opacity(0.2))
+                    .foregroundStyle(.gray3)
                     .accessibilityHidden(true)
                 }
             }
@@ -82,9 +82,7 @@ struct CongestionGraph: View {
         .onChange(of: currentDate) {
             xPosition = nil
             selectedDate = roundedToHour(currentDate)
-            for prediction in data {
-                print("\(prediction.asDate)시간대: \(prediction.passengers)명")
-            }
+//            print(adjustedForRuleMark(roundedToHour(selectedDate)))
         }
     }
 }

--- a/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
@@ -66,7 +66,7 @@ struct DateSelector: View {
                 }
                 .padding(.horizontal, 16)
             }
-            .onChange(of: selectedIndex, initial: false) { oldIndex, newIndex in
+            .onChange(of: selectedIndex, initial: false) { _, newIndex in
                 if !isUserInteraction {
                     withAnimation {
                         proxy.scrollTo(newIndex, anchor: .trailing)

--- a/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
@@ -11,7 +11,6 @@ struct DateSelector: View {
     @Binding var currentDate: Date
     @Binding var selectedDate: Date
     @Binding var selectedIndex: Int
-//    @State private var selectedIndex: Int = 0
     let range: Int = 15 // 15일치
 
     // selectedDate 기준 연속된 날짜 배열 반환

--- a/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
@@ -12,8 +12,9 @@ struct DateSelector: View {
     @Binding var selectedDate: Date
     @Binding var selectedIndex: Int
     let range: Int = 15 // 15일치
+    
+    @State private var isUserInteraction = false
 
-    // selectedDate 기준 연속된 날짜 배열 반환
     var data: [(weekday: String, day: Int, date: Date)] {
         (0 ..< range).map { offset in
             let date = Calendar.current.date(byAdding: .day, value: offset, to: currentDate)!
@@ -24,42 +25,58 @@ struct DateSelector: View {
     }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(0 ..< data.count, id: \.self) { index in
-                    Button(action: {
-                        selectedIndex = index
-                        selectedDate = data[index].date
-                    }) {
-                        VStack(alignment: index == 0 ? .trailing : index == data.count - 1 ? .leading : .center) {
-                            Text(data[index].weekday)
-                                .font(.headline)
-                                .foregroundColor(selectedIndex == index ? .white : .primary)
-                            Text("\(data[index].day)")
-                                .font(.headline)
-                                .foregroundColor(selectedIndex == index ? .white : .primary)
-                        }
-                        .frame(minWidth: 28)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 24)
-                        .background(
-                            Group {
-                                if index == 0 {
-                                    TopLeftCurvedShape()
-                                        .fill(selectedIndex == 0 ? Color.green : .gray1)
-                                } else if index == data.count - 1 {
-                                    TopRightCurvedShape()
-                                        .fill(selectedIndex == data.count - 1 ? Color.green : .gray1)
-                                } else {
-                                    selectedIndex == index ? Color.green : .gray1
-                                }
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(0 ..< data.count, id: \.self) { index in
+                        Button(action: {
+                            selectedIndex = index
+                            selectedDate = data[index].date
+                            isUserInteraction = true
+
+                        }) {
+                            VStack(alignment: index == 0 ? .trailing : index == data.count - 1 ? .leading : .center) {
+                                Text(data[index].weekday)
+                                    .font(.headline)
+                                    .foregroundColor(selectedIndex == index ? .white : .primary)
+                                Text("\(data[index].day)")
+                                    .font(.headline)
+                                    .foregroundColor(selectedIndex == index ? .white : .primary)
                             }
-                        )
+                            .frame(minWidth: 28)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 24)
+                            .background(
+                                Group {
+                                    if index == 0 {
+                                        TopLeftCurvedShape()
+                                            .fill(selectedIndex == 0 ? Color.green : .gray1)
+                                    } else if index == data.count - 1 {
+                                        TopRightCurvedShape()
+                                            .fill(selectedIndex == data.count - 1 ? Color.green : .gray1)
+                                    } else {
+                                        selectedIndex == index ? Color.green : .gray1
+                                    }
+                                }
+                            )
+                        }
+                        .cornerRadius(12)
+                        .id(index)
                     }
-                    .cornerRadius(12)
+                }
+                .padding(.horizontal, 16)
+            }
+            .onChange(of: selectedIndex, initial: false) { oldIndex, newIndex in
+                if !isUserInteraction {
+                    withAnimation {
+                        proxy.scrollTo(newIndex, anchor: .trailing)
+                    }
+                } else{
+                    withAnimation {
+                        isUserInteraction = false
+                    }
                 }
             }
-            .padding(.horizontal, 16)
         }
     }
 }

--- a/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
+++ b/SubwayCongestion/SubwayCongestion/View/Component/DateSelector.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct DateSelector: View {
     @Binding var currentDate: Date
     @Binding var selectedDate: Date
-
-    @State private var selectedIndex: Int = 0
+    @Binding var selectedIndex: Int
+//    @State private var selectedIndex: Int = 0
     let range: Int = 15 // 15일치
 
     // selectedDate 기준 연속된 날짜 배열 반환

--- a/SubwayCongestion/SubwayCongestion/View/CongestionGuideSheet.swift
+++ b/SubwayCongestion/SubwayCongestion/View/CongestionGuideSheet.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct CongestionGuideSheet: View {
     @State private var currentDate: Date = .now
     @State private var selectedDate: Date = .now
-
+    @State private var selectedIndex: Int = 0
+    
     var body: some View {
         VStack {
             Text("정보")
@@ -19,7 +20,7 @@ struct CongestionGuideSheet: View {
 
             VStack(spacing: 10) {
                 CongestionInfoRow(number: 1, description: "달력에 스와이프하여\n날짜를 확인합니다.") {
-                    DateSelector(currentDate: $currentDate, selectedDate: $selectedDate)
+                    DateSelector(currentDate: $currentDate, selectedDate: $selectedDate, selectedIndex: $selectedIndex)
                 }
 
                 CongestionInfoRow(number: 2, description: "그래프를 드래그하여 시간을 선택합니다.") {

--- a/SubwayCongestion/SubwayCongestion/View/ContentView.swift
+++ b/SubwayCongestion/SubwayCongestion/View/ContentView.swift
@@ -35,19 +35,6 @@ struct ContentView: View {
             item.month == selectedMonth && item.day == selectedDay
         }
     }
-
-    var currentDatePrediction: Prediction {
-        let calendar = Calendar.current
-        let selectedMonth = calendar.component(.month, from: selectedDate)
-        let selectedDay = calendar.component(.day, from: selectedDate)
-        let selectedTimeline = calendar.component(.hour, from: selectedDate)
-
-        print("\(selectedMonth)-\(selectedDay)-\(selectedTimeline)")
-
-        return predictions.filter { item in
-            item.month == 8 && item.day == 1 && item.timeline == 5
-        }[0]
-    }
     
     var mergedDate: Date {
         mergeDateAndHour(date: selectedDate, timeSource: currentDate)
@@ -77,7 +64,7 @@ struct ContentView: View {
                     }
                 }
                 .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                .onChange(of: selectedIndex) { newIndex in
+                .onChange(of: selectedIndex) {  _, newIndex in
                     if let newDate = Calendar.current.date(byAdding: .day, value: newIndex, to: currentDate) {
                         selectedDate = newDate
                         selectedIndex = min(max(newIndex, 0), 14)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #17 혼잡도 그래프 색션 스와이프 기능
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #17

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- tabView 적용해서 화면 스와이프 구현
- 상단 버튼 리스트와 tabView 스와이프 연동
- 상단 버튼 scroll 액션 설정(tabView 스와이프 하면 같이 움직이도록)
- 그래프 0.5초 누르고 있으면 그래프 드래그 제스처 활성화

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

![Simulator Screen Recording - iPhone 16 - 2025-07-27 at 02 51 39](https://github.com/user-attachments/assets/e853698b-de92-4ad7-b0c7-bf2c1c98000f)


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 새벽인 시간에는 인포그래픽 화면이 "해당 시간대 데이터가 없어요" 라고 나오더라고요! 새벽인 시간은 오전 5시로 고정해서 보여주기로 해서 이 부분은 같이 얘기해봐야 할 것 같습니다!

