### PR TITLE
✨ Feature: RuleMark Info 고정되도록 추가

### DIFF
--- a/SubwayCongestion/SubwayCongestion/View/ContentView.swift
+++ b/SubwayCongestion/SubwayCongestion/View/ContentView.swift
@@ -19,15 +19,15 @@ struct ContentView: View {
         SortDescriptor(\Prediction.timeline),
     ])
     var predictions: [Prediction]
+    private let calendar = Calendar.current
 
     @State private var currentDate: Date = .now
     @State private var selectedDate: Date = .now//버튼 날짜 상태
-    @State private var selectedGraphDate: Date = .now//graph 날짜 상태
+    @State private var selectedGraphDate: Date = mergeDateAndHour(date: .now, timeSource: .now)//graph 날짜 상태
     @State private var showGuideSheet: Bool = false
     @State private var selectedIndex: Int = 0
 
     var filteredPredictions: [Prediction] {
-        let calendar = Calendar.current
         let selectedMonth = calendar.component(.month, from: selectedDate)
         let selectedDay = calendar.component(.day, from: selectedDate)
 
@@ -58,7 +58,8 @@ struct ContentView: View {
                             CongestionGraph(
                                 data: filteredPredictions,
                                 currentDate: mergedDate,
-                                selectedDate: $selectedGraphDate
+                                selectedDate: $selectedGraphDate,
+                                selectedIndex: $selectedIndex
                             )
                         }
                     }
@@ -115,7 +116,7 @@ func mergeDateAndHour(date: Date, timeSource: Date) -> Date {
     let hourComponent = calendar.component(.hour, from: timeSource)
 
     var mergedComponents = dateComponents
-    mergedComponents.hour = hourComponent
+    mergedComponents.hour = max(hourComponent, 5) // 5시보다 작으면 5로 설정
     mergedComponents.minute = 0
     mergedComponents.second = 0
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #20 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- RuleMark info 박스 고정되도록 함
- 새벽인 시간에는 인포그래픽 화면이 "해당 시간대 데이터가 없어요" 라고 나오는 문제 해결(https://github.com/DeveloperAcademy-POSTECH/2025-C4-A9-Patrue/pull/23) => 새벽인 시간은 오전 5시로 고정해서 보여주도록 함

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="350" alt="simulator_screenshot_630AB618-F485-46C1-B938-EACB542AB255" src="https://github.com/user-attachments/assets/c686803e-7a94-472e-aa19-d0f5ffee8688" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 시뮬레이터 아이폰 16 UI 정상 동작 확인
- [x] 실제 기기 아이폰 14 pro 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 새벽인 시간에는 인포그래픽 화면이 "해당 시간대 데이터가 없어요" 라고 나오는 문제 해결했습니다!

---